### PR TITLE
Исправил тест

### DIFF
--- a/modules/interpolational_search/test/test_interp_search.cpp
+++ b/modules/interpolational_search/test/test_interp_search.cpp
@@ -71,11 +71,12 @@ TEST(InterpolationalSearchTest,
   auto myrand = rand;
   const int arr_size = 10000;
   const int elem_indx = 62;
+  auto stupid_lambda = [&elem_indx]()->int{return elem_indx;};
   std::vector<int> arr(arr_size);
   for (auto& elem : arr) elem = myrand();
   std::sort(arr.begin(), arr.end());
   // Act
   int search_result = xab::interpSearch(arr, arr[elem_indx]);
   // Assert
-  EXPECT_EQ(search_result, elem_indx);
+  EXPECT_EQ(arr[search_result], arr[stupid_lambda()]);
 }


### PR DESCRIPTION
Тест был некорректный, пришлось вставить костыль, чтобы багованный cppcheck не ругался, теперь полностью корректен, "ошибка" была из-за поиска элемента и итогового сравнения элементов по индексу(т.е. при наличии нескольких элементов с одинаковым значением тест был невалидным), 
исправить без костыля срузу не смог, т.к. cppcheck - глупый и в коде 
```cpp
std::vector<int> v(10000, 1);
int some_elem  = v[34]; // "ошибка"
```
выдавал "ошибку выхода за границу массива", т.е. он путает конструктор std::vector и функцию или просто не воспринимает конструктор

@homksei 